### PR TITLE
PP-96/Update server URL on testnet

### DIFF
--- a/server-config.testnet.json
+++ b/server-config.testnet.json
@@ -1,5 +1,5 @@
 {
-    "url": "http://localhost:8090",
+    "url": "https://dev.relay.rifcomputing.net:8090",
     "port": 8090,
     "relayHubAddress": "0x66Fa9FEAfB8Db66Fe2160ca7aEAc7FC24e254387",
     "relayVerifierAddress": "0x56ccdB6D312307Db7A4847c3Ea8Ce2449e9B79e9",


### PR DESCRIPTION
## What

- Update the server URL on testnet

## Why

- We changed the server URL, so we need to re-register the server.

## Refs

-  https://rsklabs.atlassian.net/browse/PP-96
