### PR TITLE
PP-138/Update Readme to include rskj configuration

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -30,7 +30,7 @@ This project works as a dependency as well as a stand-alone project.
 
 - Node version 12.18
 - RSKj Running Node. 
-  - **Note: RSKj must run with `miner.minGasPrice=1` (or higher than 0) in regtest to work properly with this server.**
+  - **Note: To work properly with this server in Regtest, please use the RSKj configuration that can be found [here](https://github.com/rsksmart/rif-relay/blob/master/rsknode/node.conf).**
 - [RIF Relay Contracts](https://github.com/anarancio/rif-relay-contracts) deployed
 
 ### Dependencies


### PR DESCRIPTION
## What

- Change the 'pre-requisites' section to include the RSKj node configuration required for Regtest.

## Why

- Many people struggled to start the server without knowing the exact RSKj configuration to use (e.g.: new joiners, QAs).