### PR TITLE
Modify start and register to use a different configuration file

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -76,7 +76,26 @@ Where:
 - **logLevel**: is the log level for the relay server.
 - **workdir**: is the absolute path to the folder where the server will store the database and all its data.
 
-Afterwards, run `npm start` to start the server.
+Afterwards, run the following command:
+
+```bash
+npm run start -- -c "<PATH>"
+``` 
+
+The long options command is also available on Linux:
+
+```bash
+npm run start -- --config_file="<PATH>"
+``` 
+
+where:
+- **CONFIG_FILE**: an optional path to an alternative configuration file. If not specified, the server will be started using server-config.json.
+
+The command shows its usage with the `-h` parameter:
+
+```bash
+npm run start -- -h
+```
 
 You can browse the `getAddr` endpoint (e.g. by doing `curl` to `http://localhost:8090/getaddr`) to verify the server is running correctly as well as visualize some useful information:
 
@@ -102,13 +121,13 @@ Once the relay server is up, you need to register it in order for it to be usabl
 Run the following command:
 
 ```bash
-npm run register -- -f "<FUNDS>" -s "<STAKE>" -a "<ACCOUNT>" -m "<MNEMONIC>"
+npm run register -- -f "<FUNDS>" -s "<STAKE>" -a "<ACCOUNT>" -m "<MNEMONIC>" -c "<PATH>"
 ``` 
 
 The long options command is also available on Linux:
 
 ```bash
-npm run register -- --funds="<FUNDS>" --stake="<STAKE>" --account="<ACCOUNT>" --mnemonic="<MNEMONIC>"
+npm run register -- --funds="<FUNDS>" --stake="<STAKE>" --account="<ACCOUNT>" --mnemonic="<MNEMONIC>" --config_file="<PATH>"
 ``` 
 
 where:
@@ -116,6 +135,7 @@ where:
 - **STAKE**: an optional the amount of stake to set up (by default 20)
 - **ACCOUNT**: an optional account to use for funding and staking (it requires the mnemonic parameter)
 - **MNEMONIC**: an optional mnemonic to use for unlocking the account parameter (it requires the account parameter)
+- **CONFIG_FILE**: an optional path to an alternative configuration file. If not specified, the server will be registered using server-config.json.
 
 The command shows its usage with the `-h` parameter:
 

--- a/Readme.md
+++ b/Readme.md
@@ -45,7 +45,7 @@ Then just run `npm install` to install all dependencies.
 
 You can use this repository directly to start your server. 
 
-To start the relay server, you need to configure the json config file located at `<PROJECT_ROOT>/jsrelay/config/relay-config.json` which has this structure:
+To start the relay server, you need to configure the json config file located at `<PROJECT_ROOT>/server-config.json` which has this structure:
    
 ```json
 {

--- a/scripts/register
+++ b/scripts/register
@@ -19,7 +19,7 @@ Options:
   -s amount     an optional amount of stake to set up (by default 20)
   -a account    an optional account to use for funding and staking (it requires the mnemonic parameter)
   -m mnemonic   an optional mnemonic to use for unlocking the account parameter (it requires the account parameter)
-  -c path       an optional path to a file containing an alternative server configuration
+  -c path       an optional path to a file containing an alternative server configuration. By default server-config.json
   -h            show this help message"
 
 LONG_HELP="Usage: $PROG [options]
@@ -28,7 +28,7 @@ Options:
   -s | --output       amount    an optional amount of stake to set up (by default 20)
   -a | --account      account   an optional account to use for funding and staking (it requires the mnemonic parameter)
   -m | --mnemonic     mnemonic  an optional mnemonic to use for unlocking the account parameter (it requires the account parameter)
-  -c | --config_file  path      an optional path to a file containing an alternative server configuration
+  -c | --config_file  path      an optional path to a file containing an alternative server configuration. By default server-config.json
   -h | --help                   show this help message"
 
 

--- a/scripts/register
+++ b/scripts/register
@@ -9,8 +9,8 @@ if [ ! -f "dist/commands/Register.js" ]; then
 fi
 
 # getopts options
-SHORT_OPTS=f:s:a:m:h
-LONG_OPTS=funds:,stake:,account:,mnemonic:,help
+SHORT_OPTS=f:s:a:m:c:h
+LONG_OPTS=funds:,stake:,account:,mnemonic:,config_file:,help
 
 # help message
 SHORT_HELP="Usage: $PROG [options]
@@ -19,15 +19,17 @@ Options:
   -s amount     an optional amount of stake to set up (by default 20)
   -a account    an optional account to use for funding and staking (it requires the mnemonic parameter)
   -m mnemonic   an optional mnemonic to use for unlocking the account parameter (it requires the account parameter)
+  -c path       an optional path to a file containing an alternative server configuration
   -h            show this help message"
 
 LONG_HELP="Usage: $PROG [options]
 Options:
-  -f | --funds      amount    an optional amount of funds to set up (by default 10)
-  -s | --output     amount    an optional amount of stake to set up (by default 20)
-  -a | --account    account   an optional account to use for funding and staking (it requires the mnemonic parameter)
-  -m | --mnemonic   mnemonic  an optional mnemonic to use for unlocking the account parameter (it requires the account parameter)
-  -h | --help                 show this help message"
+  -f | --funds        amount    an optional amount of funds to set up (by default 10)
+  -s | --output       amount    an optional amount of stake to set up (by default 20)
+  -a | --account      account   an optional account to use for funding and staking (it requires the mnemonic parameter)
+  -m | --mnemonic     mnemonic  an optional mnemonic to use for unlocking the account parameter (it requires the account parameter)
+  -c | --config_file  path      an optional path to a file containing an alternative server configuration
+  -h | --help                   show this help message"
 
 
 # default paramters
@@ -35,6 +37,7 @@ STAKE=20
 FUNDS=10
 MNEMONIC=""
 ACCOUNT=""
+CONFIG_FILE="server-config.json"
 
 HAS_GNU_ENHANCED_GETOPT=
 if getopt -T >/dev/null; then :
@@ -74,6 +77,7 @@ while [ $# -gt 0 ]; do
   -f | --funds) FUNDS=$(echo "$2" | xargs); shift;;
   -a | --account)    ACCOUNT=$(echo "$2" | xargs); shift;;
   -m | --mnemonic)   MNEMONIC=$(echo "$2" | xargs); shift;;
+  -c | --config_file) CONFIG_FILE=$(echo "$2" | xargs); shift;;
   -h | --help)  showUsage; exit 0; shift;;
   # -- means the end of the arguments; drop this, and break out of the while loop
   --) shift; break ;;
@@ -84,11 +88,12 @@ while [ $# -gt 0 ]; do
   shift
 done
 
-# Variable values set either by reading from user inpur or with the default value
+# Variable values set either by reading from user input or with the default value
 echo "STAKE: $STAKE"
 echo "FUNDS: ${FUNDS}"
 echo "MNEMONIC: ${MNEMONIC}"
 echo "ACCOUNT: ${ACCOUNT}"
+echo "CONFIG_FILE": ${CONFIG_FILE}
 
 # For debug purposes only, we should never enter in the if branch
 if [ $# -gt 0 ]; then
@@ -109,12 +114,12 @@ if [ "${FUNDS}" == "" ]; then
 fi
 
 if [ "${ACCOUNT}" == "" ] && [ "${MNEMONIC}" != "" ] || [ "${ACCOUNT}" != "" ] && [ "${MNEMONIC}" == "" ]; then
-  echo "Error, account and mnemonic are both necessary!"
+  echo "Error, account and mnemonic should be specified both or none!"
   exit 1
 fi
 
 if [ "${ACCOUNT}" != "" ] && [ "${MNEMONIC}" != "" ]; then
-  node dist/commands/Register.js --config server-config.json --funds="${FUNDS}" --stake="${STAKE}" --account="${ACCOUNT}" --mnemonic="${MNEMONIC}"
+  node dist/commands/Register.js --config="${CONFIG_FILE}" --funds="${FUNDS}" --stake="${STAKE}" --account="${ACCOUNT}" --mnemonic="${MNEMONIC}"
 else
-  node dist/commands/Register.js --config server-config.json --funds="${FUNDS}" --stake="${STAKE}"
+  node dist/commands/Register.js --config="${CONFIG_FILE}" --funds="${FUNDS}" --stake="${STAKE}"
 fi

--- a/scripts/start
+++ b/scripts/start
@@ -1,7 +1,91 @@
 #!/bin/bash
+# Copied and adapted from https://gist.github.com/hoylen/6607180
+# to cover the different versions of the getopt command avaialble on
+# Linux and macOS: https://stackoverflow.com/a/4300224/6816965
 
 if [ ! -f "dist/commands/Start.js" ]; then
   npm run build
 fi
 
-node dist/commands/Start.js --config server-config.json
+# getopts options
+SHORT_OPTS=c:h
+LONG_OPTS=funds:,config_file:,help
+
+# help message
+SHORT_HELP="Usage: $PROG [options]
+Options:
+   -c path       an optional path to a file containing an alternative server configuration
+   -h            show this help message"
+
+LONG_HELP="Usage: $PROG [options]
+Options:
+   -c | --config_file  path      an optional path to a file containing an alternative server configuration
+   -h | --help                   show this help message"
+
+
+# default paramters
+CONFIG_FILE="server-config.json"
+
+HAS_GNU_ENHANCED_GETOPT=
+if getopt -T >/dev/null; then :
+else
+  if [ $? -eq 4 ]; then
+    HAS_GNU_ENHANCED_GETOPT=yes
+  fi
+fi
+
+function showUsage() {
+  if [ -n "$HAS_GNU_ENHANCED_GETOPT" ]
+    then echo "$LONG_HELP";
+    else echo "$SHORT_HELP";
+  fi;
+}
+
+if [ -n "$HAS_GNU_ENHANCED_GETOPT" ]; then
+  # Use GNU enhanced getopt
+  if ! getopt --name "$PROG" --long $LONG_OPTS --options $SHORT_OPTS -- "$@" >/dev/null; then
+    echo "$PROG: usage error (use -h or --help for help)" >&2
+    exit 2
+  fi
+  ARGS=`getopt --name "$PROG" --long $LONG_OPTS --options $SHORT_OPTS -- "$@"`
+else
+  # Use original getopt (no long option names, no whitespace, no sorting)
+  if ! getopt $SHORT_OPTS "$@" >/dev/null; then
+    echo "$PROG: usage error (use -h for help)" >&2
+    exit 2
+  fi    
+  ARGS=`getopt $SHORT_OPTS "$@"`
+fi
+eval set -- $ARGS
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+  -c | --config_file) CONFIG_FILE=$(echo "$2" | xargs); shift;;
+  -h | --help)  showUsage; exit 0; shift;;
+  # -- means the end of the arguments; drop this, and break out of the while loop
+  --) shift; break ;;
+  # If invalid options were passed, then getopt should have reported an error,
+  # which we checked as VALID_ARGUMENTS when getopt was called...
+  *) echo "Unexpected option: $1 - this should not happen."; showUsage; exit 1;;
+  esac
+  shift
+done
+
+# Variable values set either by reading from user input or with the default value
+echo "CONFIG_FILE": ${CONFIG_FILE}
+
+# For debug purposes only, we should never enter in the if branch
+if [ $# -gt 0 ]; then
+  # Remaining parameters can be processed
+  for ARG in "$@"; do
+    echo "$PROG: argument: $ARG"
+  done
+fi
+
+if [ "${CONFIG_FILE}" == "" ]; then
+   echo "No config file was specified, starting the server with default configuration"
+   node dist/commands/Start.js --config server-config.json
+else
+   echo "Starting server with configuration specified in ${CONFIG_FILE}"
+   node dist/commands/Start.js --config=${CONFIG_FILE}
+fi

--- a/scripts/start
+++ b/scripts/start
@@ -83,7 +83,7 @@ if [ $# -gt 0 ]; then
 fi
 
 if [ "${CONFIG_FILE}" == "" ]; then
-   echo "No config file was specified, starting the server with default configuration"
+   echo "The config file specified isn't valid, starting the server with the configuration specified in server-config.json"
    node dist/commands/Start.js --config server-config.json
 else
    echo "Starting server with configuration specified in ${CONFIG_FILE}"


### PR DESCRIPTION
## What

Before this change, the only one source of configuration for the scripts start and register was server-config.json. After this change, it's possible to pass a different path as arguments. 

## Why

Because in networks different than regtest, the default configuration was failing.


